### PR TITLE
docs: change pypi badges url from pypi.com to pypi.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add our lightweight middleware to your API. Almost all processing is handled by 
 
 #### FastAPI
 
-[![PyPi version](https://badgen.net/pypi/v/api-analytics)](https://pypi.com/project/api-analytics)
+[![PyPi version](https://badgen.net/pypi/v/api-analytics)](https://pypi.org/project/api-analytics)
 
 ```bash
 pip install api-analytics[fastapi]
@@ -47,7 +47,7 @@ if __name__ == "__main__":
 
 #### Flask
 
-[![PyPi version](https://badgen.net/pypi/v/api-analytics)](https://pypi.com/project/api-analytics)
+[![PyPi version](https://badgen.net/pypi/v/api-analytics)](https://pypi.org/project/api-analytics)
 
 ```bash
 pip install api-analytics[flask]
@@ -70,7 +70,7 @@ if __name__ == "__main__":
 
 #### Django
 
-[![PyPi version](https://badgen.net/pypi/v/api-analytics)](https://pypi.com/project/api-analytics)
+[![PyPi version](https://badgen.net/pypi/v/api-analytics)](https://pypi.org/project/api-analytics)
 
 ```bash
 pip install api-analytics[django]
@@ -89,7 +89,7 @@ MIDDLEWARE = [
 
 #### Tornado
 
-[![PyPi version](https://badgen.net/pypi/v/api-analytics)](https://pypi.com/project/api-analytics)
+[![PyPi version](https://badgen.net/pypi/v/api-analytics)](https://pypi.org/project/api-analytics)
 
 ```bash
 pip install api-analytics[tornado]

--- a/analytics/python/fastapi/README.md
+++ b/analytics/python/fastapi/README.md
@@ -12,7 +12,7 @@ Head to [apianalytics.dev/generate](https://apianalytics.dev/generate) to genera
 
 Add our lightweight middleware to your API. Almost all processing is handled by our servers so there is minimal impact on the performance of your API.
 
-[![PyPi version](https://badgen.net/pypi/v/api-analytics)](https://pypi.com/project/api-analytics)
+[![PyPi version](https://badgen.net/pypi/v/api-analytics)](https://pypi.org/project/api-analytics)
 
 ```bash
 pip install fastapi-analytics

--- a/analytics/python/python/README.md
+++ b/analytics/python/python/README.md
@@ -14,7 +14,7 @@ Add our lightweight middleware to your API. Almost all processing is handled by 
 
 #### FastAPI
 
-[![PyPi version](https://badgen.net/pypi/v/api-analytics)](https://pypi.com/project/api-analytics)
+[![PyPi version](https://badgen.net/pypi/v/api-analytics)](https://pypi.org/project/api-analytics)
 
 ```bash
 pip install api-analytics[fastapi]
@@ -38,7 +38,7 @@ if __name__ == "__main__":
 
 #### Flask
 
-[![PyPi version](https://badgen.net/pypi/v/api-analytics)](https://pypi.com/project/api-analytics)
+[![PyPi version](https://badgen.net/pypi/v/api-analytics)](https://pypi.org/project/api-analytics)
 
 ```bash
 pip install api-analytics[flask]
@@ -61,7 +61,7 @@ if __name__ == "__main__":
 
 #### Django
 
-[![PyPi version](https://badgen.net/pypi/v/api-analytics)](https://pypi.com/project/api-analytics)
+[![PyPi version](https://badgen.net/pypi/v/api-analytics)](https://pypi.org/project/api-analytics)
 
 ```bash
 pip install api-analytics[django]
@@ -80,7 +80,7 @@ MIDDLEWARE = [
 
 #### Tornado
 
-[![PyPi version](https://badgen.net/pypi/v/api-analytics)](https://pypi.com/project/api-analytics)
+[![PyPi version](https://badgen.net/pypi/v/api-analytics)](https://pypi.org/project/api-analytics)
 
 ```bash
 pip install api-analytics[tornado]


### PR DESCRIPTION
https://Pypi.org is the official web for python packages, pypi.com dont work