### PR TITLE
fix(core): Improper endpoint retrieval

### DIFF
--- a/analytics/go/core/core.go
+++ b/analytics/go/core/core.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"time"
-	"strings
+	"strings"
 )
 
 var requests []RequestData

--- a/analytics/go/core/core.go
+++ b/analytics/go/core/core.go
@@ -31,8 +31,8 @@ type RequestData struct {
 	CreatedAt    string `json:"created_at"`
 }
 
-func getServerEndpoint(serverURL string) {
-	if serverURL = "" {
+func getServerEndpoint(serverURL string) string {
+	if serverURL == "" {
 		return DefaultServerUrl + "api/log-request"
 	}
 	if serverURL.HasSuffix("/") {

--- a/analytics/go/core/core.go
+++ b/analytics/go/core/core.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"time"
+	"strings
 )
 
 var requests []RequestData
@@ -33,9 +34,9 @@ type RequestData struct {
 
 func getServerEndpoint(serverURL string) string {
 	if serverURL == "" {
-		return DefaultServerUrl + "api/log-request"
+		return DefaultServerURL + "api/log-request"
 	}
-	if serverURL.HasSuffix("/") {
+	if strings.HasSuffix(serverURL, "/") {
 		return serverURL + "api/log-request"
 	}
 	return serverURL + "/api/log-request"

--- a/analytics/go/gin/analytics.go
+++ b/analytics/go/gin/analytics.go
@@ -25,7 +25,7 @@ func NewConfig() *Config {
 		GetHostname: GetHostname,
 		GetUserAgent: GetUserAgent,
 		GetIPAddress: GetIPAddress,
-		GetUserID: GetUserID
+		GetUserID: GetUserID,
 	}
 }
 


### PR DESCRIPTION
fixes an invalid check (`syntax error: cannot use assignment serverURL = "" as value`)