### PR TITLE
feat(#70): rustls-tls feature for Axum analytics middleware package

### DIFF
--- a/analytics/rust/axum/analytics/Cargo.toml
+++ b/analytics/rust/axum/analytics/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["api", "analytics", "axum", "dashboard", "middleware"]
 license = "MIT"
 name = "axum-analytics"
 repository = "https://github.com/tom-draper/api-analytics"
-version = "1.3.0"
+version = "1.3.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -20,7 +20,15 @@ chrono = {version = "0.4", features = ["unstable-locales"]}
 futures = "0.3"
 http = "1.1.0"
 lazy_static = "1.4.0"
-reqwest = {version = "0.11", features = ["json", "blocking"]}
+reqwest = { version = "0.11", features = ["json", "blocking"], default-features = false }
 serde = {version = "1.0", features = ["derive"]}
 tokio = "1.43.0"
 tower = "0.4.13"
+
+[features]
+default = ["native-tls"]
+
+# Forward TLS backend choice to reqwest
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
+rustls-tls-native-roots = ["reqwest/rustls-tls-native-roots"]


### PR DESCRIPTION
Adds `rustls-tls` feature to `axum-analytics` middleware package to use `rustls-tls` over `native-tls`.

Included in `axum-analytics v1.3.1` and above.

Resolves issue #70 